### PR TITLE
Keep track of missing translations

### DIFF
--- a/_empty/messages.ts
+++ b/_empty/messages.ts
@@ -6,6 +6,10 @@ import { MessageList } from '../types/messages'
 import { PoolGameGroup, PoolGameFoulType } from '../types/index'
 
 export default <MessageList>{
+	_entries: {
+		total: 779,
+		missing: 765
+	},
 	name: `Bloob.io`,
 	error,
 	game,
@@ -348,6 +352,7 @@ export default <MessageList>{
 		}
 	},
 	info: {
+		incompleteTranslationNotice: null,
 		betaNotice: null,
 		howToPlay: null,
 		skipStepOverHalf: null,

--- a/de/messages.ts
+++ b/de/messages.ts
@@ -6,6 +6,10 @@ import { MessageList } from '../types/messages'
 import { PoolGameGroup, PoolGameFoulType } from '../types/index'
 
 export default <MessageList>{
+	_entries: {
+		total: 779,
+		missing: 65
+	},
 	name: `Bloob.io`,
 	error,
 	game,
@@ -348,6 +352,7 @@ export default <MessageList>{
 		}
 	},
 	info: {
+		incompleteTranslationNotice: null,
 		betaNotice: null,
 		howToPlay: `Lerne das Spiel zu spielen`,
 		skipStepOverHalf: `Dieser Schritt kann auch übersprungen werden, wenn mehr als die Hälfte der Spieler dafür stimmt.`,

--- a/en/messages.ts
+++ b/en/messages.ts
@@ -6,6 +6,10 @@ import { MessageList } from '../types/messages'
 import { PoolGameGroup, PoolGameFoulType } from '../types/index'
 
 export default <MessageList>{
+	_entries: {
+		total: 779,
+		missing: 0
+	},
 	name: `Bloob.io`,
 	error,
 	game,
@@ -348,6 +352,7 @@ export default <MessageList>{
 		}
 	},
 	info: {
+		incompleteTranslationNotice: `The language you have selected is roughly {percentage}% complete. Any missing translations will be in English.`,
 		betaNotice: `This game is still being developed. Please share feedback & bugs on our %{social}`,
 		howToPlay: `Learn how to play this game`,
 		skipStepOverHalf: `This step can also be skipped if over half the users vote to.`,

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -8,29 +8,73 @@ const objectDeepKeys = obj => {
 		.reduce((x, y) => x.concat(y), Object.keys(obj))
 }
 
+const getMissingCount = obj => {
+	const data = { total: 0, missing: 0 }
+	const countCheck = value => {
+		if (value !== null && typeof value === `object`) {
+			for (const id in value) {
+				countCheck(value[id])
+			}
+		} else if (Array.isArray(value)) {
+			value.forEach(entry => countCheck(entry))
+		} else {
+			data.total++
+			if (value === null) data.missing++
+		}
+	}
+	countCheck(obj)
+	return data
+}
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const enMessageKeys = objectDeepKeys(require(`./en/messages.ts`))
+const enMessage = require(`./en/messages.ts`).default
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const enNumberFormatKeys = objectDeepKeys(require(`./en/numberFormats.ts`))
+const enNumberFormat = require(`./en/numberFormats.ts`).default
+
+const enMessageKeys = objectDeepKeys(enMessage)
+const enNumberFormatKeys = objectDeepKeys(enNumberFormat)
+
+const enCount = getMissingCount(enMessage)
+describe(`correctEntriesCount`, () => {
+	it(`should have the proper total entries count in English`, () => {
+		expect(enCount.total).toBe(enMessage._entries.total)
+	})
+	it(`should have no missing entries in English`, () => {
+		expect(enCount.missing).toBe(0)
+	})
+})
 
 for (const folder of [...supportedLocales, `_empty`]) {
 	if (folder === `en`) continue
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const messages = require(`./${folder}/messages.ts`).default
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const numberFormat = require(`./${folder}/numberFormats.ts`).default
 
 	describe(`translatedMessages`, () => {
 		it(`should have all English translations keys in "${folder}"`, () => {
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
-			const messageKeys = objectDeepKeys(require(`./${folder}/messages.ts`))
-
+			const messageKeys = objectDeepKeys(messages)
 			expect(symmetricDifference(enMessageKeys, messageKeys)).toHaveLength(0)
 		})
 	})
 
 	describe(`translatedNumberFormats`, () => {
 		it(`should have all English number translations keys in "${folder}"`, () => {
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
-			const numberFormatKeys = objectDeepKeys(require(`./${folder}/numberFormats.ts`))
-
+			const numberFormatKeys = objectDeepKeys(numberFormat)
 			expect(symmetricDifference(enNumberFormatKeys, numberFormatKeys)).toHaveLength(0)
+		})
+	})
+
+	describe(`correctEntriesCount`, () => {
+		const count = getMissingCount(messages)
+		it(`should match the English total entries count for "${folder}"`, () => {
+			expect(count.total).toBe(enCount.total)
+		})
+		it(`should have the proper total entries count for "${folder}"`, () => {
+			expect(count.total).toBe(messages._entries.total)
+		})
+		it(`should have the proper missing entries count for "${folder}"`, () => {
+			expect(count.missing).toBe(messages._entries.missing)
 		})
 	})
 }

--- a/nl/messages.ts
+++ b/nl/messages.ts
@@ -6,6 +6,10 @@ import { MessageList } from '../types/messages'
 import { PoolGameGroup, PoolGameFoulType } from '../types/index'
 
 export default <MessageList>{
+	_entries: {
+		total: 779,
+		missing: 0
+	},
 	name: `Bloob.io`,
 	error,
 	game,
@@ -348,6 +352,7 @@ export default <MessageList>{
 		}
 	},
 	info: {
+		incompleteTranslationNotice: `De taal die je hebt geselecteerd is ongeveer {percentage}% compleet. Elke ontbrekende vertaling zal in het Engels verschijnen.`,
 		betaNotice: `Dit spel is nog in ontwikkeling. Deel feedback en bugs op onze %{social}`,
 		howToPlay: `Bekijk hoe je dit spel speelt`,
 		skipStepOverHalf: `Deze stap kan ook worden overgeslagen als meer dan de helft van de gebruikers daarvoor stemt.`,

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -6,6 +6,15 @@ import { PoolGameGroup, PoolGameFoulType } from './index'
 
 export type MessageList = {
 	/**
+	 * Keeps track of the total number of entries in the project
+	 * and how much of them are still missing. This can be updated by
+	 * running `yarn test`
+	 */
+	_entries: {
+		total: number
+		missing: number
+	}
+	/**
 	 * Site name - Bloob.io
 	 */
 	name: string
@@ -1580,6 +1589,13 @@ export type MessageList = {
 	 * Generic information (tooltips, explanations)
 	 */
 	info: {
+		/**
+		 * Shown when the user is using a language that is less than 90% complete.
+		 *
+		 * @argument {number} percentage - Percentage on how complete the translation is
+		 */
+		incompleteTranslationNotice: string
+
 		/**
 		 * Shown as a notice when a game is still in beta. It encourages players
 		 * to report feedback.


### PR DESCRIPTION
In order to give the user a good experience, a warning will appear when a language isn't fully completed yet. This aims to keep track of the translated entries.